### PR TITLE
Created ProtectedDisplay wrapper component

### DIFF
--- a/app/(pages)/_components/ProtectedDisplay/ProtectedDisplay.tsx
+++ b/app/(pages)/_components/ProtectedDisplay/ProtectedDisplay.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useAuth } from '@hooks/useAuth';
+import LoginForm from 'app/(pages)/judges/_components/LoginForm/LoginForm';
+
+export default function ProtectedDisplay({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, loading } = useAuth();
+  if (loading) {
+    return 'loading...';
+  }
+  if (user === null) {
+    return (
+      <div>
+        This page requires authentication to view
+        <LoginForm />
+      </div>
+    );
+  } else {
+    return children;
+  }
+}

--- a/app/(pages)/_contexts/AuthContext.tsx
+++ b/app/(pages)/_contexts/AuthContext.tsx
@@ -43,6 +43,11 @@ function getAuthFromClient(): AuthTokenBody | null {
   }
 }
 
+const deleteAuthTokenCookie = () => {
+  // Delete the 'auth-token' cookie
+  Cookies.remove('auth-token', { path: '/' });
+};
+
 export type { AuthTokenBody, AuthProviderValue };
 
 export const AuthContext = createContext({});
@@ -61,6 +66,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const logout = useCallback(() => {
+    deleteAuthTokenCookie();
     setUser(null);
   }, []);
 

--- a/app/(pages)/_contexts/AuthContext.tsx
+++ b/app/(pages)/_contexts/AuthContext.tsx
@@ -45,7 +45,7 @@ function getAuthFromClient(): AuthTokenBody | null {
 
 const deleteAuthTokenCookie = () => {
   // Delete the 'auth-token' cookie
-  Cookies.remove('auth-token', { path: '/' });
+  Cookies.remove('auth_token', { path: '/' });
 };
 
 export type { AuthTokenBody, AuthProviderValue };

--- a/app/(pages)/judges/_components/LogoutButton/LogoutButton.tsx
+++ b/app/(pages)/judges/_components/LogoutButton/LogoutButton.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useAuth } from '@hooks/useAuth';
+
+export default function LogoutButton({
+  children,
+  style,
+}: {
+  children?: React.ReactNode;
+  style?: object;
+}) {
+  const { logout } = useAuth();
+  return (
+    <button style={style} onClick={logout}>
+      {children}
+    </button>
+  );
+}

--- a/app/(pages)/judges/auth-test/page.tsx
+++ b/app/(pages)/judges/auth-test/page.tsx
@@ -1,0 +1,11 @@
+import ProtectedDisplay from '@components/ProtectedDisplay/ProtectedDisplay';
+import LogoutButton from '../_components/LogoutButton/LogoutButton';
+
+export default function AuthTest() {
+  return (
+    <ProtectedDisplay>
+      Protected information
+      <LogoutButton>Logout</LogoutButton>
+    </ProtectedDisplay>
+  );
+}


### PR DESCRIPTION
Wrap your pages in a ProtectedDisplay to require a login to view page.

LogoutButton component created as well as an example for how to log users out.
- LogoutButton calls the logout function from the useAuth hook.
- Sets user to null in the AuthContext and deletes 'auth_token' JWT token